### PR TITLE
quick fix: CMakeList.txt not working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_executable(engine
     # Test Files
     test/test.c
 )
-if (${USING_CLION} EQUAL 1)
+if (USING_CLION)
     target_link_libraries(engine librscore.a -lm)
 else()
     find_package(MPI REQUIRED)


### PR DESCRIPTION
When compiling from shell, USING_CLION is not defined so this line throws an exception and doesn't generate Makefile.