### PR TITLE
v0.0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,8 @@ add_executable(engine
         src/service/master.cpp
         src/service/link.cpp
         )
-if (${USING_CLION} EQUAL 1)
+
+if (DEFINED CLION)
     target_link_libraries(engine librscore.a -lm)
 else()
     find_package(MPI REQUIRED)


### PR DESCRIPTION
# Notes

#### CMake Fix

To contextualize, developers of the **ispd-exa-engine** were unable to compile the project inside the CLion since the CMake was unable to find the **MPI** package to link it with the simulator. Therefore, a terminal was needed to be used to compile the project without errors. However, a condition was needed to be put into the **CMakeLists.txt** to able the CLion to compile correctly the project (but in this case, without linking the MPI) for the **static analyzer** to work (since while the CMake cannot be compiled, then the CLion's static analyzer does not work).

Previously, it was needed to define the **USING_CLION** argument in the CMake's command-line argument to be able to compile the project correctly. From now on, this **strict requirement** has been removed.

* **USING_CLION=0**: This was used to indicate that the CLion was compiling the project and, therefore, the MPI should not be linked to the simulator.

* **USING_CLION=1**: This was used to indicate that the project was being compiled out of the CLion (_for instance, in a terminal_) and, therefore, the MPI should be linked with the simulator.

From now on, there is no need for the terminal to specify the latter case above. However, is necessary for those that use CLion to specify from now on, the argument **CLION** to make the static analyzer work.

To summarize,

* Terminal project building, should use: `cmake .`
* CLion project building should use: `cmake -DCLION=. .` 