### PR TITLE
v0.0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,13 @@ include_directories(include)
 link_directories(lib)
 add_executable(engine
         # Include Files
-        include/service/service.hpp
         include/engine.hpp
         include/core/core.hpp
         include/simulator/simulator.hpp
         include/simulator/timewarp.hpp
         include/customer/customer.hpp
         include/event/event.hpp
+        include/service/service.hpp
         include/service/machine.hpp
         include/service/master.hpp
         include/service/link.hpp
@@ -23,6 +23,7 @@ add_executable(engine
         include/math/distribution/distribution.hpp
         include/allocator/rootsim_allocator.hpp
         include/routing/table.hpp
+        include/routing/route.hpp
 
         # Source Files
         main.cpp

--- a/include/customer/customer.hpp
+++ b/include/customer/customer.hpp
@@ -12,6 +12,12 @@ class Customer
 {
 };
 
+enum class TaskCompletionState
+{
+    JUST_GENERATED,
+    PROCESSED
+};
+
 /**
  * @brief A task represents the smallest unit of work
  *        for a processing resource
@@ -20,8 +26,8 @@ class Task : public Customer
 {
 public:
     /**
-     * @brief Constructor which specifies the task identifier, the processing size
-     *        in megaflops and the communication size in megabits of this task.
+     * @brief Constructor which specifies the task identifier, the processing
+     * size in megaflops and the communication size in megabits of this task.
      *
      * @details
      *        It is the caller's responsibility to ensure
@@ -36,8 +42,19 @@ public:
      * @param processingSize the processing size
      * @param communicationSize the communication size
      */
-    explicit Task(const uint64_t tid, const double processingSize, const double communicationSize) noexcept
-        : m_Tid(tid), m_ProcSize(processingSize), m_CommSize(communicationSize)
+    explicit Task(const uint64_t tid,
+                  const double   processingSize,
+                  const double   communicationSize) noexcept
+        : m_Tid(tid), m_ProcSize(processingSize), m_CommSize(communicationSize),
+          m_CompletionState(TaskCompletionState::JUST_GENERATED)
+    {}
+
+    explicit Task(const uint64_t            tid,
+                  const double              processingSize,
+                  const double              communicationSize,
+                  const TaskCompletionState completionState) noexcept
+        : m_Tid(tid), m_ProcSize(processingSize), m_CommSize(communicationSize),
+          m_CompletionState(completionState)
     {}
 
     /**
@@ -70,6 +87,16 @@ public:
         return m_Tid;
     }
 
+    /**
+     * @brief Returns the task completion state.
+     *
+     * @return the task completion state
+     */
+    ENGINE_INLINE TaskCompletionState getCompletionState() const
+    {
+        return m_CompletionState;
+    }
+
 private:
     /**
      * @brief It represents the task id.
@@ -85,6 +112,11 @@ private:
      * @brief It represents the communication size of this task in megabits.
      */
     double m_CommSize;
+
+    /**
+     * @brief It indicates the task completion state.
+     */
+    TaskCompletionState m_CompletionState;
 };
 
 #endif // ENGINE_CUSTOMER_HPP

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -1,8 +1,7 @@
 #ifndef ENGINE_HPP
 #define ENGINE_HPP
 
-#include <customer/customer.hpp>
-#include <event/event.hpp>
+#include <core/core.hpp>
 
 #define TASK_ARRIVAL 1
 

--- a/include/engine.hpp
+++ b/include/engine.hpp
@@ -24,12 +24,19 @@ extern "C"
 
 #endif // ROOT-Sim
 
-ENGINE_INLINE void schedule_event(const sid_t id, const timestamp_t time, const unsigned eventType, const void *event,
+namespace ispd
+{
+
+ENGINE_INLINE void schedule_event(const sid_t       id,
+                                  const timestamp_t time,
+                                  const unsigned    eventType,
+                                  const void       *event,
                                   const std::size_t eventSize)
 {
-#if SIM == 0
+#ifdef ROOTSIM_ENGINE
     ScheduleNewEvent(id, time, eventType, event, eventSize);
 #endif // ROOT-Sim
 }
+} // namespace ispd
 
 #endif // ENGINE_HPP

--- a/include/routing/route.hpp
+++ b/include/routing/route.hpp
@@ -36,10 +36,11 @@ public:
      */
     explicit RouteDescriptor()
     {
-        m_Src             = static_cast<uint64_t>(-1);
-        m_Dest            = static_cast<uint64_t>(-1);
-        m_PreviousService = static_cast<uint64_t>(-1);
-        m_Offset          = 0;
+        m_Src                 = static_cast<uint64_t>(-1);
+        m_Dest                = static_cast<uint64_t>(-1);
+        m_PreviousService     = static_cast<uint64_t>(-1);
+        m_Offset              = 0;
+        m_ForwardingDirection = true;
     }
 
     /**
@@ -51,13 +52,16 @@ public:
      * @param dest the destination service identifier
      * @param offset an offset used for indexing the next service's identifier
      *               in the route between the source and destination services
+     * @param forwardingDirection this flag is used to indicate the direction of
+     *                            forwarding of the packet.
      */
     explicit RouteDescriptor(const uint64_t    src,
                              const uint64_t    dest,
                              const uint64_t    previousService,
-                             const std::size_t offset)
+                             const std::size_t offset,
+                             const bool        forwardingDirection)
         : m_Src(src), m_Dest(dest), m_PreviousService(previousService),
-          m_Offset(offset)
+          m_Offset(offset), m_ForwardingDirection(forwardingDirection)
     {}
 
     /**
@@ -101,6 +105,20 @@ public:
     ENGINE_INLINE uint64_t getPreviousService() const
     {
         return m_PreviousService;
+    }
+
+    /**
+     * @brief Returns the direction in which te packet is being forwarded
+     *        in a route. If the value is `true`, then the direction of
+     *        forwarding is from the master to the slave. Otherwise, if the
+     *        value is `false`, then the direction of forwardding is from the
+     *        slave to the master.
+     *
+     * @return the direction in which the packet is being forwarded in a route
+     */
+    ENGINE_INLINE bool getForwardingDirection() const
+    {
+        return m_ForwardingDirection;
     }
 
 private:
@@ -157,6 +175,20 @@ private:
      *        provided by the `Route` and `RoutingTable` classes.
      */
     std::size_t m_Offset;
+
+    /**
+     * @brief The route forward direction.
+     *
+     * @details
+     *       This flag indicates if the packet in the route should be forwarded
+     *       in the direction from the master to the slave or vice-versa.
+     *       Therefore, this can be indicated by turning on/off this flag.
+     *
+     *       If this flag is `true`, then the direction of forwarding is from
+     *       the mater to the slave. Otherwise, the direction of forwarding is
+     *       from the slave to the master.
+     */
+    bool m_ForwardingDirection;
 };
 
 #endif // ENGINE_ROUTING_ROUTE_HPP

--- a/include/service/machine.hpp
+++ b/include/service/machine.hpp
@@ -8,9 +8,10 @@
 
 struct MachineMetrics
 {
-    double m_ProcMFlops;
-    double m_ProcTime;
-    int    m_ProcTasks;
+    timestamp_t m_LastActivityTime;
+    double      m_ProcMFlops;
+    double      m_ProcTime;
+    int         m_ProcTasks;
 
     /**
      * @brief This metric contains the amount of packets that this machine
@@ -119,18 +120,12 @@ public:
         return m_Metrics;
     }
 
-    ENGINE_TEMPORARY timestamp_t getLocalVirtualTime() const
-    {
-        return m_LVT;
-    }
-
 private:
-    MachineMetrics               m_Metrics{};
-    double                       m_PowerPerProc;
-    double                       m_LoadFactor;
-    int                          m_Cores;
-    timestamp_t                 *m_CoreFreeTimes;
-    ENGINE_TEMPORARY timestamp_t m_LVT;
+    MachineMetrics m_Metrics{};
+    double         m_PowerPerProc;
+    double         m_LoadFactor;
+    int            m_Cores;
+    timestamp_t   *m_CoreFreeTimes;
 };
 
 #endif // ENGINE_MACHINE_HPP

--- a/include/service/master.hpp
+++ b/include/service/master.hpp
@@ -1,11 +1,18 @@
 #ifndef ENGINE_MASTER_HPP
 #define ENGINE_MASTER_HPP
 
+#include "core/core.hpp"
 #include <algorithm>
 #include <allocator/rootsim_allocator.hpp>
 #include <scheduler/scheduler.hpp>
 #include <service/service.hpp>
 #include <vector>
+
+struct MasterMetrics
+{
+    timestamp_t m_LastActivityTime;
+    unsigned    m_CompletedTasks;
+};
 
 class Master : public Service
 {
@@ -57,6 +64,12 @@ public:
         m_Scheduler->addResource(slaveId);
     }
 
+    ENGINE_INLINE
+    const MasterMetrics &getMetrics() const
+    {
+        return m_Metrics;
+    }
+
 private:
     Scheduler<sid_t> *m_Scheduler;
 
@@ -79,6 +92,8 @@ private:
      *        will need to be used.
      */
     std::vector<sid_t> *m_Links;
+
+    MasterMetrics m_Metrics{};
 };
 
 #endif // ENGINE_MASTER_HPP

--- a/include/service/service.hpp
+++ b/include/service/service.hpp
@@ -2,6 +2,7 @@
 #define ENGINE_SERVICE_HPP
 
 #include <engine.hpp>
+#include <event/event.hpp>
 
 class Service
 {

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -1,0 +1,11 @@
+#ifndef ENGINE_TYPES_HPP
+#define ENGINE_TYPES_HPP
+
+#include <cstdint>
+
+/**
+ * @brief The service identifier type.
+ */
+typedef uint32_t sid_t;
+
+#endif // ENGINE_TYPES_HPP

--- a/src/service/link.cpp
+++ b/src/service/link.cpp
@@ -38,5 +38,5 @@ void Link::onTaskArrival(timestamp_t now, const Event *event)
             getId());
 
     /* Send the event to the destination machine */
-    schedule_event(sendTo, departureTime, TASK_ARRIVAL, &e, sizeof(e));
+    ispd::schedule_event(sendTo, departureTime, TASK_ARRIVAL, &e, sizeof(e));
 }

--- a/src/service/link.cpp
+++ b/src/service/link.cpp
@@ -24,7 +24,8 @@ void Link::onTaskArrival(timestamp_t now, const Event *event)
             RouteDescriptor(routeDescriptor.getSource(),
                             routeDescriptor.getDestination(),
                             getId(),
-                            routeDescriptor.getOffset()));
+                            routeDescriptor.getOffset(),
+                            routeDescriptor.getForwardingDirection()));
 
     sid_t sendTo;
 

--- a/src/service/machine.cpp
+++ b/src/service/machine.cpp
@@ -15,7 +15,7 @@ static void doMachinePacketForwarding(const sid_t       machineId,
     const auto destination      = routeDescriptor.getDestination();
     const auto offset           = routeDescriptor.getOffset();
     const auto forwardDirection = routeDescriptor.getForwardingDirection();
-    const auto newOffset        = forwardDirection ? offset + 1ULL : offset - 1ULL;
+    const auto newOffset = forwardDirection ? offset + 1ULL : offset - 1ULL;
 
     // It fetches the routing from the routing table using the source
     // and destination identifier.
@@ -31,6 +31,8 @@ static void doMachinePacketForwarding(const sid_t       machineId,
 
 void Machine::onTaskArrival(const timestamp_t time, const Event *event)
 {
+    m_Metrics.m_LastActivityTime = time;
+
     // It checks if the packet destination is not equals to this machine.
     // Therefore, the packet should be forwarded by the machine to the next
     // service in the route.
@@ -56,5 +58,22 @@ void Machine::onTaskArrival(const timestamp_t time, const Event *event)
     const timestamp_t departureTime = time + waitingTime + procTime;
 
     m_CoreFreeTimes[coreIndex] = departureTime;
-    m_LVT                      = departureTime;
+
+    const auto &routeDescriptor = event->getRouteDescriptor();
+
+    Event e(Task(task.getTid(),
+                 task.getProcessingSize(),
+                 task.getCommunicationSize(),
+                 TaskCompletionState::PROCESSED),
+            RouteDescriptor(routeDescriptor.getSource(),
+                            routeDescriptor.getDestination(),
+                            getId(),
+                            routeDescriptor.getOffset() - 2ULL,
+                            false));
+
+    ispd::schedule_event(routeDescriptor.getPreviousService(),
+                         departureTime,
+                         TASK_ARRIVAL,
+                         &e,
+                         sizeof(e));
 }

--- a/src/service/machine.cpp
+++ b/src/service/machine.cpp
@@ -11,9 +11,11 @@ static void doMachinePacketForwarding(const sid_t       machineId,
 {
     const auto &routeDescriptor = event->getRouteDescriptor();
 
-    const auto source      = routeDescriptor.getSource();
-    const auto destination = routeDescriptor.getDestination();
-    const auto offset      = routeDescriptor.getOffset();
+    const auto source           = routeDescriptor.getSource();
+    const auto destination      = routeDescriptor.getDestination();
+    const auto offset           = routeDescriptor.getOffset();
+    const auto forwardDirection = routeDescriptor.getForwardingDirection();
+    const auto newOffset        = forwardDirection ? offset + 1ULL : offset - 1ULL;
 
     // It fetches the routing from the routing table using the source
     // and destination identifier.
@@ -21,7 +23,8 @@ static void doMachinePacketForwarding(const sid_t       machineId,
 
     // Prepare the event to be send to the next service.
     Event e(event->getTask(),
-            RouteDescriptor(source, destination, machineId, offset + 1ULL));
+            RouteDescriptor(
+                source, destination, machineId, newOffset, forwardDirection));
 
     ispd::schedule_event((*route)[offset], time, TASK_ARRIVAL, &e, sizeof(e));
 }

--- a/src/service/machine.cpp
+++ b/src/service/machine.cpp
@@ -23,7 +23,7 @@ static void doMachinePacketForwarding(const sid_t       machineId,
     Event e(event->getTask(),
             RouteDescriptor(source, destination, machineId, offset + 1ULL));
 
-    schedule_event((*route)[offset], time, TASK_ARRIVAL, &e, sizeof(e));
+    ispd::schedule_event((*route)[offset], time, TASK_ARRIVAL, &e, sizeof(e));
 }
 
 void Machine::onTaskArrival(const timestamp_t time, const Event *event)

--- a/src/service/master.cpp
+++ b/src/service/master.cpp
@@ -5,15 +5,19 @@ extern RoutingTable *g_RoutingTable;
 
 void Master::onTaskArrival(timestamp_t time, const Event *event)
 {
+    const auto &routeDescriptor     = event->getRouteDescriptor();
+    const auto  offset              = routeDescriptor.getOffset();
+    const auto  forwardingDirection = routeDescriptor.getForwardingDirection();
+    const auto  newOffset = forwardingDirection ? offset + 1ULL : offset - 1ULL;
+
     /* Schedule the slave which will receive the task */
     sid_t scheduledSlave = m_Scheduler->schedule();
 
     /* Prepare the event */
-    Event e(event->getTask(),
-            RouteDescriptor(getId(),
-                            scheduledSlave,
-                            getId(),
-                            event->getRouteDescriptor().getOffset() + 1ULL));
+    Event e(
+        event->getTask(),
+        RouteDescriptor(
+            getId(), scheduledSlave, getId(), newOffset, forwardingDirection));
 
     const Route *route = g_RoutingTable->getRoute(getId(), scheduledSlave);
 

--- a/src/service/master.cpp
+++ b/src/service/master.cpp
@@ -18,5 +18,5 @@ void Master::onTaskArrival(timestamp_t time, const Event *event)
     const Route *route = g_RoutingTable->getRoute(getId(), scheduledSlave);
 
     /* Schedule the event to the scheduled slave */
-    schedule_event((*route)[0], time, TASK_ARRIVAL, &e, sizeof(e));
+    ispd::schedule_event((*route)[0], time, TASK_ARRIVAL, &e, sizeof(e));
 }

--- a/src/service/master.cpp
+++ b/src/service/master.cpp
@@ -1,3 +1,4 @@
+#include "customer/customer.hpp"
 #include <routing/table.hpp>
 #include <service/master.hpp>
 
@@ -5,6 +6,14 @@ extern RoutingTable *g_RoutingTable;
 
 void Master::onTaskArrival(timestamp_t time, const Event *event)
 {
+    m_Metrics.m_LastActivityTime = time;
+
+    if (event->getTask().getCompletionState() ==
+        TaskCompletionState::PROCESSED) {
+        m_Metrics.m_CompletedTasks++;
+        return;
+    }
+
     const auto &routeDescriptor     = event->getRouteDescriptor();
     const auto  offset              = routeDescriptor.getOffset();
     const auto  forwardingDirection = routeDescriptor.getForwardingDirection();

--- a/test/model1/test.cpp
+++ b/test/model1/test.cpp
@@ -1,4 +1,6 @@
+#include "../test.hpp"
 #include <allocator/rootsim_allocator.hpp>
+#include <cstdio>
 #include <iostream>
 #include <routing/table.hpp>
 #include <scheduler/round_robin.hpp>
@@ -49,20 +51,8 @@ int main(int argc, char **argv)
         return m;
     });
 
-    s->registerServiceFinalizer(2ULL, [](Service *service) {
-        Machine *m = (Machine *)service;
-
-        std::cout << "Machine Metrics\n" << std::endl;
-        std::cout << " - LVT: " << m->getLocalVirtualTime() << " @ LP ("
-                  << m->getId() << ")" << std::endl;
-        std::cout << " - Processed MFlops: " << m->getMetrics().m_ProcMFlops
-                  << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed Time: " << m->getMetrics().m_ProcTime
-                  << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed Tasks: " << m->getMetrics().m_ProcTasks
-                  << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << std::endl;
-    });
+    ispd::test::registerMasterServiceFinalizer(s, 0ULL);
+    ispd::test::registerMachineServiceFinalizer(s, 2ULL);
 
     s->simulate();
 

--- a/test/model1/test.cpp
+++ b/test/model1/test.cpp
@@ -32,7 +32,7 @@ int main(int argc, char **argv)
 
         for (uint64_t i = 0ULL; i < taskAmount; i++) {
             Event e(Task(i, 50.0, 80.0));
-            schedule_event(0ULL, 0.0, TASK_ARRIVAL, &e, sizeof(e));
+            ispd::schedule_event(0ULL, 0.0, TASK_ARRIVAL, &e, sizeof(e));
         }
 
         return m;

--- a/test/model2/test.cpp
+++ b/test/model2/test.cpp
@@ -1,12 +1,14 @@
-#include <iostream>
+#include "../test.hpp"
 #include <allocator/rootsim_allocator.hpp>
+#include <cstdio>
+#include <iostream>
+#include <routing/table.hpp>
 #include <scheduler/round_robin.hpp>
 #include <service/link.hpp>
 #include <service/machine.hpp>
 #include <service/master.hpp>
 #include <simulator/timewarp.hpp>
 #include <string>
-#include <routing/table.hpp>
 
 extern RoutingTable *g_RoutingTable;
 
@@ -52,18 +54,8 @@ int main(int argc, char **argv)
         return m;
     });
 
-
-    s->registerServiceFinalizer(2ULL, [](Service *service) {
-        Machine *m = (Machine *)service;
-
-        std::cout << "Machine Metrics\n" << std::endl;
-        std::cout << " - LVT: " << m->getLocalVirtualTime() << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed MFlops: " << m->getMetrics().m_ProcMFlops << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed Time: " << m->getMetrics().m_ProcTime << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed Tasks: " << m->getMetrics().m_ProcTasks << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << std::endl;
-
-    });
+    ispd::test::registerMasterServiceFinalizer(s, 0ULL);
+    ispd::test::registerMachineServiceFinalizer(s, 2ULL);
 
     s->simulate();
 

--- a/test/model2/test.cpp
+++ b/test/model2/test.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
 
         for (uint64_t i = 0ULL; i < taskAmount; i++) {
             Event e(Task(i, 50.0, 80.0));
-            schedule_event(0ULL, jitter, TASK_ARRIVAL, &e, sizeof(e));
+            ispd::schedule_event(0ULL, jitter, TASK_ARRIVAL, &e, sizeof(e));
             jitter += 1e-52;
         }
 

--- a/test/model_ring/test.cpp
+++ b/test/model_ring/test.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
 
         for (uint64_t i = 0ULL; i < taskAmount; i++) {
             Event e(Task(i, 50.0, 80.0));
-            schedule_event(0ULL, 0.0, TASK_ARRIVAL, &e, sizeof(e));
+            ispd::schedule_event(0ULL, 0.0, TASK_ARRIVAL, &e, sizeof(e));
         }
 
         return m;

--- a/test/model_ring/test.cpp
+++ b/test/model_ring/test.cpp
@@ -56,6 +56,7 @@ int main(int argc, char **argv)
     s->registerService(8ULL, []() { return NEW_MACHINE(8ULL); });
     s->registerService(9ULL, []() { return NEW_LINK(9ULL, 8ULL, 0ULL); });
 
+    ispd::test::registerMasterServiceFinalizer(s, 0ULL);
     for (sid_t machineId = 2ULL; machineId < 9ULL; machineId += 2ULL)
         ispd::test::registerMachineServiceFinalizer(s, machineId);
 

--- a/test/model_ring/test.cpp
+++ b/test/model_ring/test.cpp
@@ -1,3 +1,4 @@
+#include "../test.hpp"
 #include <allocator/rootsim_allocator.hpp>
 #include <iostream>
 #include <routing/table.hpp>
@@ -55,24 +56,8 @@ int main(int argc, char **argv)
     s->registerService(8ULL, []() { return NEW_MACHINE(8ULL); });
     s->registerService(9ULL, []() { return NEW_LINK(9ULL, 8ULL, 0ULL); });
 
-    for (sid_t machineId = 2ULL; machineId < 9ULL; machineId += 2ULL) {
-        s->registerServiceFinalizer(machineId, [](Service *service) {
-            Machine *m = static_cast<Machine *>(service);
-
-            std::cout << "Machine Metrics\n" << std::endl;
-            std::cout << " - LVT: " << m->getLocalVirtualTime() << " @ LP ("
-                      << m->getId() << ")" << std::endl;
-            std::cout << " - Processed MFlops: " << m->getMetrics().m_ProcMFlops
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << " - Processed Time: " << m->getMetrics().m_ProcTime
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << " - Processed Tasks: " << m->getMetrics().m_ProcTasks
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << " - Forwarded Packets: " << m->getMetrics().m_ForwardedPackets
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << std::endl;
-        });
-    }
+    for (sid_t machineId = 2ULL; machineId < 9ULL; machineId += 2ULL)
+        ispd::test::registerMachineServiceFinalizer(s, machineId);
 
     s->simulate();
 

--- a/test/model_route/test.cpp
+++ b/test/model_route/test.cpp
@@ -80,6 +80,7 @@ int main(int argc, char **argv)
         return l;
     });
 
+    ispd::test::registerMasterServiceFinalizer(s, 0ULL);
     for (sid_t i = 2ULL; i <= 6ULL; i += 2ULL)
         ispd::test::registerMachineServiceFinalizer(s, i);
 

--- a/test/model_route/test.cpp
+++ b/test/model_route/test.cpp
@@ -1,3 +1,4 @@
+#include "../test.hpp"
 #include <allocator/rootsim_allocator.hpp>
 #include <iostream>
 #include <routing/table.hpp>
@@ -79,22 +80,8 @@ int main(int argc, char **argv)
         return l;
     });
 
-    for (sid_t i = 2ULL; i <= 6ULL; i += 2ULL) {
-        s->registerServiceFinalizer(i, [](Service *service) {
-            Machine *m = (Machine *)service;
-
-            std::cout << "Machine Metrics\n" << std::endl;
-            std::cout << " - LVT: " << m->getLocalVirtualTime() << " @ LP ("
-                      << m->getId() << ")" << std::endl;
-            std::cout << " - Processed MFlops: " << m->getMetrics().m_ProcMFlops
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << " - Processed Time: " << m->getMetrics().m_ProcTime
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << " - Processed Tasks: " << m->getMetrics().m_ProcTasks
-                      << " @ LP (" << m->getId() << ")" << std::endl;
-            std::cout << std::endl;
-        });
-    }
+    for (sid_t i = 2ULL; i <= 6ULL; i += 2ULL)
+        ispd::test::registerMachineServiceFinalizer(s, i);
 
     s->simulate();
 

--- a/test/model_route/test.cpp
+++ b/test/model_route/test.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
 
         for (uint64_t i = 0ULL; i < taskAmount; i++) {
             Event e(Task(i, 50.0, 80.0));
-            schedule_event(0ULL, 0.0, TASK_ARRIVAL, &e, sizeof(e));
+            ispd::schedule_event(0ULL, 0.0, TASK_ARRIVAL, &e, sizeof(e));
         }
 
         return m;

--- a/test/model_star/test.cpp
+++ b/test/model_star/test.cpp
@@ -1,3 +1,4 @@
+#include "../test.hpp"
 #include <iostream>
 #include <routing/table.hpp>
 #include <scheduler/round_robin.hpp>
@@ -61,7 +62,8 @@ int main(int argc, char **argv)
                 // Prepare the workload.
                 for (unsigned i = 0; i < taskAmount; i++) {
                     Event e(Task(i, 10 + i, 50 + i));
-                    ispd::schedule_event(id, jitter, TASK_ARRIVAL, &e, sizeof(e));
+                    ispd::schedule_event(
+                        id, jitter, TASK_ARRIVAL, &e, sizeof(e));
                     jitter += 1e-52;
                 }
 
@@ -86,20 +88,8 @@ int main(int argc, char **argv)
         }
     }
 
-    s->registerServiceFinalizer(1ULL, [](Service *service) {
-        Machine *m = static_cast<Machine *>(service);
-
-        std::cout << "Machine Metrics\n" << std::endl;
-        std::cout << " - LVT: " << m->getLocalVirtualTime() << " @ LP ("
-                  << m->getId() << ")" << std::endl;
-        std::cout << " - Processed MFlops: " << m->getMetrics().m_ProcMFlops
-                  << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed Time: " << m->getMetrics().m_ProcTime
-                  << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << " - Processed Tasks: " << m->getMetrics().m_ProcTasks
-                  << " @ LP (" << m->getId() << ")" << std::endl;
-        std::cout << std::endl;
-    });
+    ispd::test::registerMasterServiceFinalizer(s, 0ULL);
+    ispd::test::registerMachineServiceFinalizer(s, 1ULL);
 
     s->simulate();
 

--- a/test/model_star/test.cpp
+++ b/test/model_star/test.cpp
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
                 // Prepare the workload.
                 for (unsigned i = 0; i < taskAmount; i++) {
                     Event e(Task(i, 10 + i, 50 + i));
-                    schedule_event(id, jitter, TASK_ARRIVAL, &e, sizeof(e));
+                    ispd::schedule_event(id, jitter, TASK_ARRIVAL, &e, sizeof(e));
                     jitter += 1e-52;
                 }
 

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -1,0 +1,86 @@
+#ifndef ENGINE_TEST_HPP
+#define ENGINE_TEST_HPP
+
+#include <core/core.hpp>
+#include <cstdio>
+#include <service/machine.hpp>
+#include <service/master.hpp>
+#include <simulator/simulator.hpp>
+
+namespace ispd
+{
+namespace test
+{
+/**
+ * @brief It register a master service finalizer that is used to print
+ * 	  the master's statistics at the end of the simulation for the master
+ * 	  with the specified service identifier.
+ *
+ * @param simulator the simulator in which the service finalizer will
+ * 		    be registered to
+ * @param serviceId the service identifier
+ */
+inline void registerMasterServiceFinalizer(Simulator *const simulator,
+                                           const sid_t      serviceId)
+{
+    // It checks if the simulator has not been specified. If so, then
+    // the program will be aborted immediately.
+    if (not simulator)
+        die("registerMachineServiceFinalizer: Simulator is NULL");
+
+    simulator->registerServiceFinalizer(serviceId, [](Service *service) {
+        const Master        *m       = static_cast<Master *>(service);
+        const MasterMetrics &metrics = m->getMetrics();
+        std::printf("Master Metrics\n"
+                    " - Last Activity Time: %lf @ LP (%lu)\n"
+                    " - Completed Tasks: %u @ LP (%lu)\n\n",
+                    metrics.m_LastActivityTime,
+                    m->getId(),
+                    metrics.m_CompletedTasks,
+                    m->getId());
+    });
+}
+/**
+ * @brief It register a machine service finalizer that is used to print
+ *    	  the machine's statistics at the end of the simulation for the machine
+ *    	  with the specified service identifier.
+ *
+ * @param simulator the simulator in which the service finalizer will be
+ * 		    registered to
+ * @param serviceId the service identifier
+ */
+inline void registerMachineServiceFinalizer(Simulator *const simulator,
+                                            const sid_t      serviceId)
+{
+    // It checks if the simulator has not been specified. If so, then
+    // the program will be aborted immediately.
+    if (not simulator)
+        die("registerMachineServiceFinalizer: Simulator is NULL");
+
+    simulator->registerServiceFinalizer(serviceId, [](Service *service) {
+        const Machine        *m       = static_cast<Machine *>(service);
+        const MachineMetrics &metrics = m->getMetrics();
+
+        std::printf("Machine Metrics\n"
+                    " - Last Activity Time: %lf @ LP (%lu)\n"
+                    " - Processed MFLOPS..: %lf @ LP (%lu)\n"
+                    " - Processed Time....: %lf @ LP (%lu)\n"
+                    " - Processed Tasks...: %d @ LP (%lu)\n"
+                    " - Forwarded Packets.: %u @ LP (%lu)\n"
+                    "\n",
+                    metrics.m_LastActivityTime,
+                    m->getId(),
+                    metrics.m_ProcMFlops,
+                    m->getId(),
+                    metrics.m_ProcTime,
+                    m->getId(),
+                    metrics.m_ProcTasks,
+                    m->getId(),
+                    metrics.m_ForwardedPackets,
+                    m->getId());
+    });
+}
+
+} // namespace test
+} // namespace ispd
+#endif // ENGINE_TEST_HPP


### PR DESCRIPTION
# Notes

#### Forward Direction

Previously, only one direction is being used to forward the packets by the links in the route, that is, since a link is composed by a source service and a destination service, when a link receive a task, this would only route the packet from source to the destination, even if the destination had sent that task. With that, the direction of forwarding is now taken into account.

#### Master Aware of Completed Tasks

Machines are now routing messages back to the master after task processing completion, such that, the master is now aware about which tasks have been processed.

#### Namespaces

Until now, no _name collision_ has occurred, however, the a namespace called **ispd** is now being used to target the simulator and prevent future name collisions.